### PR TITLE
Add Spark download widget to guide pages

### DIFF
--- a/docs/get_started/en/LILYGO-Spark/LILYGO-Spark-en.md
+++ b/docs/get_started/en/LILYGO-Spark/LILYGO-Spark-en.md
@@ -1,36 +1,32 @@
 # LILYGO Spark User Guide
 
-# Software Download and Installation
-
 ## Software Download
 
-1. Visit the LILYGO Spark official GitHub repository: [https://github.com/Xinyuan-LilyGO/LILYGO-Spark](https://github.com/Xinyuan-LilyGO/LILYGO-Spark);
-        
-![alt text](image-1.png)
-      
+<div id="spark-widget" data-theme="green"></div>
 
-2. After entering the repository page, click the 「Releases」 option in the top navigation bar to go to the releases page.
-
-![alt text](image.png)
-
-
-3. According to your computer's operating system (Windows, macOS, Linux), select the corresponding version of the installation package to download, and wait for the download to complete.
-        
-![alt text](image-2.png)
+Click **"Download"** above to get the installer for your current platform, or click **"All Platforms"** to expand the full list of downloads for macOS, Windows, and Linux.
 
 ## Software Installation
 
-1. Locate the downloaded installation package and double-click to start the installer;
-        
-![alt text](image-3.png)
-      
+### Windows
 
-2. Windows users: If a system security prompt appears during installation, follow the pop-up instructions and click `Continue` to complete the installation process;
+1. Locate the downloaded `.exe` file and double-click to start the installer;
+
+![alt text](image-3.png)
+
+2. If a SmartScreen security prompt appears, click `More info` → `Run anyway` to continue;
 
 ![alt text](image-4.png)
-      
 
-3. After installation, the software will start automatically without manual operation.
+3. After installation, the software will start automatically.
+
+### macOS
+
+The macOS version has been **Apple Notarized**, so you can install it directly without any additional security settings.
+
+1. Open the downloaded `.dmg` file and drag LILYGO Spark to the Applications folder;
+2. On first launch, macOS will show a confirmation dialog — click `Open` to proceed;
+3. No need to go to System Settings → Privacy & Security to allow the app, as it is already notarized by Apple.
 
 # Software Function Overview
 

--- a/docs/get_started/zh/LILYGO-Spark/LILYGO-Spark-zh.md
+++ b/docs/get_started/zh/LILYGO-Spark/LILYGO-Spark-zh.md
@@ -1,39 +1,34 @@
 # LILYGO Spark 使用指南
 
-# 软件获取与安装
-
 ## 软件下载
 
-1. 访问 LILYGO Spark 官方GitHub仓库：[https://github.com/Xinyuan-LilyGO/LILYGO-Spark](https://github.com/Xinyuan-LilyGO/LILYGO-Spark)；
-        
-![alt text](image-1.png)
-      
+<div id="spark-widget" data-theme="green"></div>
 
-2. 进入仓库页面后，点击顶部导航栏中的「Releases」选项，进入版本发布页面
-
-![alt text](image.png)
-
-
-3. 根据自身电脑操作系统（Windows、macOS、Linux），选择对应版本的安装包进行下载，等待下载完成。
-        
-![alt text](image-2.png)
+点击上方 **「下载」** 按钮获取当前平台的安装包，或点击 **「All Platforms」** 展开查看 macOS、Windows、Linux 全部下载选项。
 
 ## 软件安装
 
-1. 找到下载完成的安装包，双击启动安装程序；
-        
-![alt text](image-3.png)
-      
+### Windows
 
-2. Windows系统用户：安装过程中若出现系统安全提示，按弹窗指引依次点击 `继续`，完成安装流程；
+1. 找到下载完成的 `.exe` 安装包，双击启动安装程序；
+
+![alt text](image-3.png)
+
+2. 若出现 SmartScreen 安全提示，点击 `更多信息` → `仍要运行` 继续安装；
 
 ![alt text](image-4.png)
-      
 
-3. 安装完成后，软件将自动启动，无需手动触发启动操作。
-        
+3. 安装完成后，软件将自动启动。
 
-      
+### macOS
+
+macOS 版本已通过 **Apple 公证（Notarized）**，可直接安装使用，无需额外的安全设置。
+
+1. 打开下载的 `.dmg` 文件，将 LILYGO Spark 拖入「应用程序」文件夹；
+2. 首次启动时，macOS 会弹出确认对话框，点击「打开」即可；
+3. 由于已经过 Apple 公证，无需前往「系统设置 → 隐私与安全性」中手动允许。
+
+
 
 # 软件功能概述
 

--- a/static/js/custom.js
+++ b/static/js/custom.js
@@ -1,0 +1,158 @@
+// LILYGO Wiki — Load Spark release data + render download widget
+(function () {
+  function loadWidget() {
+    if (!document.getElementById('spark-widget')) return;
+    var s = document.createElement('script');
+    s.src = '/static/js/spark-latest.js';
+    s.onload = function () { renderSparkWidget(); };
+    s.onerror = function () {
+      var s2 = document.createElement('script');
+      s2.src = 'https://lilygo.oss-accelerate.aliyuncs.com/spark-releases/latest/spark-latest.js';
+      s2.onload = function () { renderSparkWidget(); };
+      document.body.appendChild(s2);
+    };
+    document.body.appendChild(s);
+  }
+
+  function renderSparkWidget() {
+    var R = window.SPARK_LATEST;
+    if (!R) return;
+    var host = document.getElementById('spark-widget');
+    if (!host) return;
+
+    function sz(b) { return (b / 1048576).toFixed(1) + ' MB'; }
+
+    /* platform detect */
+    function detect() {
+      var ua = navigator.userAgent.toLowerCase();
+      if (ua.indexOf('mac') !== -1) {
+        try {
+          var c = document.createElement('canvas'), gl = c.getContext('webgl');
+          if (gl) { var d = gl.getExtension('WEBGL_debug_renderer_info'); if (d && gl.getParameter(d.UNMASKED_RENDERER_WEBGL).indexOf('Apple') !== -1) return { k: 'macOS-arm64', l: 'macOS (Apple Silicon)' }; }
+        } catch (e) {}
+        return { k: 'macOS-arm64', l: 'macOS' };
+      }
+      if (ua.indexOf('win') !== -1) return { k: 'windows-x64-setup', l: 'Windows' };
+      if (ua.indexOf('linux') !== -1) return { k: 'linux-x86_64-AppImage', l: 'Linux' };
+      return { k: 'windows-x64-setup', l: 'Windows' };
+    }
+
+    var plat = detect();
+    var dlAsset = R.assets && R.assets[plat.k];
+    var dlUrl = dlAsset ? dlAsset.url : 'https://github.com/Xinyuan-LilyGO/LILYGO-Spark/releases';
+    var ver = 'v' + R.version;
+
+    var groups = [
+      { label: 'macOS', keys: [
+        { k: 'macOS-arm64', l: 'Apple Silicon (.dmg)' },
+        { k: 'macOS-x64', l: 'Intel (.dmg)' },
+        { k: 'macOS-universal', l: 'Universal (.dmg)' }
+      ]},
+      { label: 'Windows', keys: [
+        { k: 'windows-x64-setup', l: 'x64 Installer (.exe)' },
+        { k: 'windows-x64-portable', l: 'x64 Portable (.exe)' },
+        { k: 'windows-arm64-setup', l: 'ARM64 Installer (.exe)' }
+      ]},
+      { label: 'Linux', keys: [
+        { k: 'linux-x86_64-AppImage', l: 'x86_64 (.AppImage)' },
+        { k: 'linux-amd64-deb', l: 'amd64 (.deb)' },
+        { k: 'linux-x86_64-rpm', l: 'x86_64 (.rpm)' }
+      ]}
+    ];
+
+    /* inject CSS */
+    if (!document.getElementById('spw-css')) {
+      var st = document.createElement('style');
+      st.id = 'spw-css';
+      st.textContent =
+        '#spark-widget{font-family:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif!important;line-height:1.5!important}' +
+        '#spark-widget *{box-sizing:border-box!important}' +
+        '#spark-widget a{text-decoration:none!important}' +
+        '#spark-widget table,#spark-widget td,#spark-widget tr{border:none!important;background:none!important;padding:0!important}' +
+        '.spw-wrap{border:1px solid #d1fae5!important;border-radius:14px!important;overflow:hidden!important}' +
+        /* card */
+        '.spw-card{padding:20px 24px!important;display:flex!important;align-items:center!important;justify-content:space-between!important;flex-wrap:wrap!important;gap:16px!important;background:#fff!important;border-bottom:1px solid #d1fae5!important}' +
+        '.spw-card-info{display:flex!important;align-items:center!important;gap:12px!important}' +
+        '.spw-card-icon{width:38px!important;height:38px!important;border-radius:10px!important;display:flex!important;align-items:center!important;justify-content:center!important;flex-shrink:0!important;background:linear-gradient(135deg,#10b981,#059669)!important;color:#fff!important}' +
+        '.spw-card-icon svg{width:20px!important;height:20px!important}' +
+        '.spw-card-text{display:block!important}' +
+        '.spw-card-title{font-size:16px!important;font-weight:700!important;color:#111827!important;line-height:1.3!important;display:block!important}' +
+        '.spw-card-ver{font-size:12px!important;color:#9ca3af!important;margin-top:2px!important;line-height:1.3!important;display:block!important}' +
+        '.spw-card-btns{display:flex!important;gap:8px!important;flex-wrap:wrap!important;align-items:center!important}' +
+        '.spw-btn-dl{display:inline-flex!important;align-items:center!important;gap:6px!important;padding:10px 22px!important;border-radius:24px!important;text-decoration:none!important;font-size:14px!important;font-weight:600!important;border:none!important;cursor:pointer!important;background:#10b981!important;color:#fff!important;box-shadow:0 2px 8px rgba(16,185,129,.3)!important;transition:all .15s!important;line-height:1.4!important}' +
+        '.spw-btn-dl:hover{background:#059669!important;box-shadow:0 4px 14px rgba(5,150,105,.35)!important;transform:translateY(-1px)!important}' +
+        '.spw-btn-dl svg{width:16px!important;height:16px!important}' +
+        '.spw-btn-tog{font-size:13px!important;font-weight:600!important;cursor:pointer!important;display:inline-flex!important;align-items:center!important;gap:5px!important;line-height:1.4!important;color:#10b981!important;border:1.5px solid #a7f3d0!important;padding:9px 18px!important;border-radius:24px!important;background:#fff!important;transition:all .15s!important}' +
+        '.spw-btn-tog:hover{border-color:#10b981!important;background:#ecfdf5!important}' +
+        '.spw-btn-tog svg{width:13px!important;height:13px!important;transition:transform .25s!important}' +
+        '.spw-btn-tog.open svg{transform:rotate(180deg)!important}' +
+        /* expand panel */
+        '.spw-panel{max-height:0!important;overflow:hidden!important;transition:max-height .35s cubic-bezier(.4,0,.2,1)!important;background:#ecfdf5!important}' +
+        '.spw-panel.open{max-height:800px!important}' +
+        '.spw-panel-inner{padding:16px 24px 20px!important}' +
+        /* platform label */
+        '.spw-plat{font-size:11px!important;font-weight:700!important;text-transform:uppercase!important;letter-spacing:.08em!important;color:#059669!important;margin-bottom:10px!important;display:block!important}' +
+        '.spw-plat-group{margin-bottom:16px!important}' +
+        '.spw-plat-group:last-child{margin-bottom:0!important}' +
+        /* pills */
+        '.spw-pills{display:flex!important;flex-wrap:wrap!important;gap:10px!important}' +
+        '.spw-pill{display:inline-flex!important;align-items:center!important;gap:8px!important;padding:11px 20px!important;border-radius:28px!important;text-decoration:none!important;font-size:13px!important;font-weight:500!important;white-space:nowrap!important;background:#fff!important;border:1.5px solid #d1fae5!important;color:#374151!important;box-shadow:0 1px 3px rgba(0,0,0,.04)!important;transition:all .2s!important}' +
+        '.spw-pill:hover{border-color:#10b981!important;background:#f0fdf9!important;box-shadow:0 4px 14px rgba(16,185,129,.12)!important}' +
+        '.spw-pill-size{font-size:11px!important;color:#9ca3af!important;font-weight:400!important}';
+      document.head.appendChild(st);
+    }
+
+    var dlSvg = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>';
+    var chevSvg = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>';
+    var boltSvg = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>';
+
+    /* build expand panel */
+    var pillsHtml = '';
+    for (var g = 0; g < groups.length; g++) {
+      pillsHtml += '<div class="spw-plat-group">';
+      pillsHtml += '<span class="spw-plat">' + groups[g].label + '</span>';
+      pillsHtml += '<div class="spw-pills">';
+      for (var i = 0; i < groups[g].keys.length; i++) {
+        var ak = groups[g].keys[i], asset = R.assets && R.assets[ak.k];
+        if (asset) {
+          pillsHtml += '<a class="spw-pill" href="' + asset.url + '">' +
+            '<span>' + ak.l + '</span>' +
+            '<span class="spw-pill-size">' + sz(asset.size) + '</span></a>';
+        }
+      }
+      pillsHtml += '</div></div>';
+    }
+
+    host.innerHTML =
+      '<div class="spw-wrap">' +
+        '<div class="spw-card">' +
+          '<div class="spw-card-info">' +
+            '<div class="spw-card-icon">' + boltSvg + '</div>' +
+            '<div class="spw-card-text">' +
+              '<span class="spw-card-title">LILYGO Spark</span>' +
+              '<span class="spw-card-ver">' + ver + ' \u00b7 macOS / Windows / Linux</span>' +
+            '</div>' +
+          '</div>' +
+          '<div class="spw-card-btns">' +
+            '<a class="spw-btn-dl" href="' + dlUrl + '">' + dlSvg + ' Download for ' + plat.l + '</a>' +
+            '<button class="spw-btn-tog" type="button">All Platforms ' + chevSvg + '</button>' +
+          '</div>' +
+        '</div>' +
+        '<div class="spw-panel"><div class="spw-panel-inner">' + pillsHtml + '</div></div>' +
+      '</div>';
+
+    /* bind toggle */
+    var tog = host.querySelector('.spw-btn-tog');
+    var panel = host.querySelector('.spw-panel');
+    tog.addEventListener('click', function () {
+      panel.classList.toggle('open');
+      tog.classList.toggle('open');
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', loadWidget);
+  } else {
+    loadWidget();
+  }
+})();


### PR DESCRIPTION
## Summary
- Add auto-updating Spark download widget (Style C green pills) to EN + ZH guide pages
- `custom.js`: loads release data from `spark-latest.js` (local fallback to OSS CDN), renders platform-detected download button + expandable all-platforms pill list
- Installation guide updated with separate Windows/macOS steps, macOS Apple Notarization note

## Test plan
- [ ] Verify widget renders on EN page `/get_started/en/LILYGO-Spark/`
- [ ] Verify widget renders on ZH page `/get_started/zh/LILYGO-Spark/`
- [ ] Click "Download" button → triggers download for detected platform
- [ ] Click "All Platforms" → expands/collapses pill list
- [ ] Each pill links to correct OSS CDN download URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)